### PR TITLE
Fix: ineffective hosts.

### DIFF
--- a/Navicat_Keygen_Patch_By_DFoX/NC.cs
+++ b/Navicat_Keygen_Patch_By_DFoX/NC.cs
@@ -1390,7 +1390,7 @@ namespace Navicat_Keygen_Patch_By_DFoX
                         {
                             using (StreamWriter stream = new StreamWriter(hostPath, true, Encoding.Default))
                             {
-                                stream.WriteLine(cosascrivere);
+                                stream.WriteLine(Environment.NewLine + cosascrivere);
                             }
                         }
                     }


### PR DESCRIPTION
Rules will not take effect when hosts not end with newline char. Because there are two rules in one line.

example:
127.0.0.1       localhost
->
127.0.0.1       localhost127.0.0.1       activate.navicat.com